### PR TITLE
Call disable() on server shutdown

### DIFF
--- a/src/main/java/org/geysermc/floodgate/FabricMod.java
+++ b/src/main/java/org/geysermc/floodgate/FabricMod.java
@@ -45,5 +45,9 @@ public class FabricMod implements ModInitializer {
             injector.getInstance(FloodgateLogger.class)
                     .translatedInfo("floodgate.core.finish", endCtm - ctm);
         });
+
+        ServerLifecycleEvents.SERVER_STOPPING.register((server) -> {
+            platform.disable();
+        });
     }
 }


### PR DESCRIPTION
The `disable()` method of the `FabricPlatform` should be called when the server is shutting down in order to properly stop the news checker, otherwise the server just hangs indefinitely. Together with GeyserMC/Floodgate#248, this should fix GeyserMC/Floodgate-Fabric#25.