### PR TITLE
Exclude slf4j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     shadow("org.geysermc.floodgate:common:${project.mod_version}") {
         exclude group: 'com.google.guava', module: "guava"
         exclude group: 'com.google.code.gson', module: "gson"
+        exclude group: 'org.slf4j', module: "slf4j-api"
         exclude group: 'net.kyori', module: '*' // Let Adventure-Platform provide its desired Adventure version
     }
 


### PR DESCRIPTION
slf4j now exists in Vanilla, and shadowing it here causes issues with other mods, such as Iris Shaders.