### PR TITLE
Actually fix building for real this time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,9 +60,6 @@ repositories {
     maven {
         url = 'https://oss.sonatype.org/content/repositories/snapshots'
     }
-    maven {
-        url = "https://repo.incendo.org/content/repositories/releases"
-    }
     // Standard OpenCollab repositories
     maven {
         name = 'opencollab-release-repo'


### PR DESCRIPTION
It seems that [repo.incendo.org](https://repo.incendo.org/content/repositories/releases/org/geysermc/floodgate/common/2.1.0-SNAPSHOT/maven-metadata.xml) is dead and therefore builds fail due to timing out when trying to access floodgate common