### PR TITLE
FabricProxyLite support

### DIFF
--- a/src/main/java/org/geysermc/floodgate/addon/data/FabricDataHandler.java
+++ b/src/main/java/org/geysermc/floodgate/addon/data/FabricDataHandler.java
@@ -12,7 +12,7 @@ import net.minecraft.server.network.ServerLoginPacketListenerImpl;
 import org.geysermc.floodgate.MinecraftServerHolder;
 import org.geysermc.floodgate.api.logger.FloodgateLogger;
 import org.geysermc.floodgate.mixin.ConnectionMixin;
-import org.geysermc.floodgate.mixin.ClientIntentionPacketMixin;
+import org.geysermc.floodgate.mixin.ClientIntentionPacketMixinInterface;
 import org.geysermc.floodgate.mixin_interface.ServerLoginPacketListenerSetter;
 import com.mojang.authlib.GameProfile;
 import io.netty.channel.ChannelHandlerContext;
@@ -48,7 +48,7 @@ public final class FabricDataHandler extends CommonDataHandler {
     protected Object setHostname(Object handshakePacket, String hostname) {
         // While it would be ideal to simply create a new handshake packet, the packet constructor
         // does not allow us to set the protocol version
-        ((ClientIntentionPacketMixin) handshakePacket).setAddress(hostname);
+        ((ClientIntentionPacketMixinInterface) handshakePacket).setAddress(hostname);
         return handshakePacket;
     }
 

--- a/src/main/java/org/geysermc/floodgate/mixin/ClientIntentionPacketMixin.java
+++ b/src/main/java/org/geysermc/floodgate/mixin/ClientIntentionPacketMixin.java
@@ -1,19 +1,14 @@
 package org.geysermc.floodgate.mixin;
 
 import net.minecraft.network.protocol.handshake.ClientIntentionPacket;
-import org.geysermc.floodgate.util.ProxyUtils;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
 @Mixin(ClientIntentionPacket.class)
 public class ClientIntentionPacketMixin {
-    @ModifyConstant(method = "<init>*", constant = @Constant(intValue = 255))
+    @ModifyConstant(method = "<init>(Lnet/minecraft/network/FriendlyByteBuf;)V", constant = @Constant(intValue = 255))
     private int floodgate$modifyMaxCapacity(int defaultValue) {
-        if (ProxyUtils.isProxyData()) {
-            //let's not modify if unnecessary
             return Short.MAX_VALUE;
-        }
-        return defaultValue;
     }
 }

--- a/src/main/java/org/geysermc/floodgate/mixin/ClientIntentionPacketMixin.java
+++ b/src/main/java/org/geysermc/floodgate/mixin/ClientIntentionPacketMixin.java
@@ -8,7 +8,7 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 @Mixin(ClientIntentionPacket.class)
 public class ClientIntentionPacketMixin {
     @ModifyConstant(method = "<init>(Lnet/minecraft/network/FriendlyByteBuf;)V", constant = @Constant(intValue = 255))
-    private int floodgate$modifyMaxCapacity(int defaultValue) {
+    private int floodgate$setHandshakeLength(int defaultValue) {
             return Short.MAX_VALUE;
     }
 }

--- a/src/main/java/org/geysermc/floodgate/mixin/ClientIntentionPacketMixin.java
+++ b/src/main/java/org/geysermc/floodgate/mixin/ClientIntentionPacketMixin.java
@@ -1,14 +1,19 @@
 package org.geysermc.floodgate.mixin;
 
 import net.minecraft.network.protocol.handshake.ClientIntentionPacket;
+import org.geysermc.floodgate.util.ProxyUtils;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Mutable;
-import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
 @Mixin(ClientIntentionPacket.class)
-public interface ClientIntentionPacketMixin {
-
-    @Accessor("hostName")
-    @Mutable
-    void setAddress(String address);
+public class ClientIntentionPacketMixin {
+    @ModifyConstant(method = "<init>*", constant = @Constant(intValue = 255))
+    private int floodgate$modifyMaxCapacity(int defaultValue) {
+        if (ProxyUtils.isProxyData()) {
+            //let's not modify if unnecessary
+            return Short.MAX_VALUE;
+        }
+        return defaultValue;
+    }
 }

--- a/src/main/java/org/geysermc/floodgate/mixin/ClientIntentionPacketMixinInterface.java
+++ b/src/main/java/org/geysermc/floodgate/mixin/ClientIntentionPacketMixinInterface.java
@@ -1,0 +1,14 @@
+package org.geysermc.floodgate.mixin;
+
+import net.minecraft.network.protocol.handshake.ClientIntentionPacket;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ClientIntentionPacket.class)
+public interface ClientIntentionPacketMixinInterface {
+
+    @Accessor("hostName")
+    @Mutable
+    void setAddress(String address);
+}

--- a/src/main/java/org/geysermc/floodgate/util/MixinConfigPlugin.java
+++ b/src/main/java/org/geysermc/floodgate/util/MixinConfigPlugin.java
@@ -1,0 +1,49 @@
+package org.geysermc.floodgate.util;
+
+import net.fabricmc.loader.api.FabricLoader;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+    public class MixinConfigPlugin implements IMixinConfigPlugin {
+
+        @Override
+        public void onLoad(String mixinPackage) {
+
+        }
+
+        @Override
+        public String getRefMapperConfig() {
+            return null;
+        }
+
+        @Override
+        public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+            if (mixinClassName.equals("org/geysermc/floodgate/mixin/ClientIntentionPacketMixin")) {
+                //returns true if fabricproxy-lite is present, therefore loading the mixin. If not present, the mixin will not be loaded.
+                return FabricLoader.getInstance().isModLoaded("fabricproxy-lite");
+            }
+            return true;
+        }
+
+        @Override
+        public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+
+        }
+
+        @Override
+        public List<String> getMixins() {
+            return null;
+        }
+
+        @Override
+        public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+        }
+
+        @Override
+        public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+        }
+    }

--- a/src/main/java/org/geysermc/floodgate/util/MixinConfigPlugin.java
+++ b/src/main/java/org/geysermc/floodgate/util/MixinConfigPlugin.java
@@ -8,42 +8,40 @@ import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 import java.util.List;
 import java.util.Set;
 
-    public class MixinConfigPlugin implements IMixinConfigPlugin {
+public class MixinConfigPlugin implements IMixinConfigPlugin {
 
-        @Override
-        public void onLoad(String mixinPackage) {
-
-        }
-
-        @Override
-        public String getRefMapperConfig() {
-            return null;
-        }
-
-        @Override
-        public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
-            if (mixinClassName.equals("org/geysermc/floodgate/mixin/ClientIntentionPacketMixin")) {
-                //returns true if fabricproxy-lite is present, therefore loading the mixin. If not present, the mixin will not be loaded.
-                return FabricLoader.getInstance().isModLoaded("fabricproxy-lite");
-            }
-            return true;
-        }
-
-        @Override
-        public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
-
-        }
-
-        @Override
-        public List<String> getMixins() {
-            return null;
-        }
-
-        @Override
-        public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
-        }
-
-        @Override
-        public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
-        }
+    @Override
+    public void onLoad(String mixinPackage) {
     }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        if (mixinClassName.equals("org/geysermc/floodgate/mixin/ClientIntentionPacketMixin")) {
+            //returns true if fabricproxy-lite is present, therefore loading the mixin. If not present, the mixin will not be loaded.
+            return FabricLoader.getInstance().isModLoaded("fabricproxy-lite");
+        }
+        return true;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+}

--- a/src/main/java/org/geysermc/floodgate/util/ProxyUtils.java
+++ b/src/main/java/org/geysermc/floodgate/util/ProxyUtils.java
@@ -1,9 +1,0 @@
-package org.geysermc.floodgate.util;
-
-import net.fabricmc.loader.api.FabricLoader;
-
-public class ProxyUtils {
-    public static boolean isProxyData() {
-        return FabricLoader.getInstance().isModLoaded("fabricproxy-lite");
-    }
-}

--- a/src/main/java/org/geysermc/floodgate/util/ProxyUtils.java
+++ b/src/main/java/org/geysermc/floodgate/util/ProxyUtils.java
@@ -1,0 +1,9 @@
+package org.geysermc.floodgate.util;
+
+import net.fabricmc.loader.api.FabricLoader;
+
+public class ProxyUtils {
+    public static boolean isProxyData() {
+        return FabricLoader.getInstance().isModLoaded("fabricproxy-lite");
+    }
+}

--- a/src/main/resources/floodgate.mixins.json
+++ b/src/main/resources/floodgate.mixins.json
@@ -11,6 +11,7 @@
     "ServerConnectionListenerMixin",
     "ServerLoginPacketListenerImplMixin"
   ],
+  "plugin": "org.geysermc.floodgate.util.MixinConfigPlugin",
   "injectors": {
     "defaultRequire": 1
   }

--- a/src/main/resources/floodgate.mixins.json
+++ b/src/main/resources/floodgate.mixins.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_16",
   "mixins": [
     "ChunkMapMixin",
+    "ClientIntentionPacketMixinInterface",
     "ClientIntentionPacketMixin",
     "ConnectionMixin",
     "ServerConnectionListenerMixin",


### PR DESCRIPTION
As discussed on discord, here's a funky fix for #56  - thanks for all the helpful input, especially Tim203, Camotoy, and Konica!
I'm implementing this workaround to make sure Velocity servers with modern player info forwarding, send-floodgate-data & global linking set to true can properly send players & forward data to Fabric server backends with FabricProxyLite and Floodgate-fabric installed.

To fix the issue of too long handshake packets, a mixin extends the limit of 255 to the Short.MAX_VALUE when the mod fabricproxylite is present, as this fix isn't needed otherwise.

I've tested this with a Velocity proxy + Fabric 1.19.3 server - worked fine with a linked bedrock player. I haven't tested java players & unlinked bedrock players yet; but since those worked without this fix i couldn't imagine this messing with it; will test it later today though.

