### PR TITLE
1.19.4 bump, fix "critical injection failure" issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
         because "Commands library implementation for Fabric"
     })
 
-    include(modImplementation('net.kyori:adventure-platform-fabric:5.6.0-SNAPSHOT') {
+    include(modImplementation('net.kyori:adventure-platform-fabric:5.8.0-SNAPSHOT') {
         because "Chat library implementation for Fabric that includes methods for communicating with the server"
         // Thanks to zml for this fix
         // The package modifies Brigadier which causes a LinkageError at runtime if included

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,6 +26,6 @@
   "depends": {
     "fabricloader": ">=0.14.6",
     "fabric": "*",
-    "minecraft": ">=1.19.3"
+    "minecraft": ">=1.19.4"
   }
 }


### PR DESCRIPTION
fix #86 - caused by version mismatch of adventure-platform-fabric, as per https://github.com/kyoripowered/adventure-platform-fabric#versions
