### PR TITLE
fix mixinplugin

### DIFF
--- a/src/main/java/org/geysermc/floodgate/util/MixinConfigPlugin.java
+++ b/src/main/java/org/geysermc/floodgate/util/MixinConfigPlugin.java
@@ -21,7 +21,7 @@ public class MixinConfigPlugin implements IMixinConfigPlugin {
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
-        if (mixinClassName.equals("org/geysermc/floodgate/mixin/ClientIntentionPacketMixin")) {
+        if (mixinClassName.equals("org.geysermc.floodgate.mixin.ClientIntentionPacketMixin")) {
             //returns true if fabricproxy-lite is present, therefore loading the mixin. If not present, the mixin will not be loaded.
             return FabricLoader.getInstance().isModLoaded("fabricproxy-lite");
         }


### PR DESCRIPTION
so apparently, this whole time, the mixin config plugin was not actually doing it's job and always applying the mixin...
noticed it after floodgate-fabric conflicted with fabricproxy-legacy, which uh, should not happen as our hacky fix should only be applied for fabricproxy-lite.
As for whether legacy needs the mixin for send-floodgate-data to work - i don't think so. If it does, then our hack wouldn't work anyways as that mod has a redirect mixin, breaking ours.

