### PR TITLE
fix building & 1.20 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
         exclude group: "org.ow2.asm", module: "*" // From Events lib
     }
 
-    include(modImplementation('cloud.commandframework:cloud-fabric:1.8.0-SNAPSHOT') {
+    include(modImplementation('cloud.commandframework:cloud-fabric:1.8.3') {
         because "Commands library implementation for Fabric"
     })
 

--- a/src/main/resources/floodgate.accesswidener
+++ b/src/main/resources/floodgate.accesswidener
@@ -4,3 +4,5 @@ accessWidener v1 named
 accessible class net/minecraft/server/network/ServerLoginPacketListenerImpl$State
 # For player skin refreshing
 accessible class net/minecraft/server/level/ChunkMap$TrackedEntity
+# To access skins
+accessible field net/minecraft/world/entity/Entity level Lnet/minecraft/world/level/Level;


### PR DESCRIPTION
Seems like cloud.commandframework:cloud-fabric:1.8.0-SNAPSHOT isnt available anymore. 1.8.0 is - or, while at it, 1.8.3.
Also added fix for https://github.com/GeyserMC/Floodgate-Fabric/issues/94.