### PR TITLE
Target 1.20.4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,13 +5,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@72f2cec99f417b1a1c5e2e88945068983b7965f9
+      - uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4
+      - uses: actions/setup-java@4075bfc1b51bf22876335ae1cd589602d60d8758
         with:
           distribution: 'temurin'
           java-version: 17
       - name: Publish to Modrinth
+        uses: gradle/gradle-build-action@3bfe3a46584a206fb8361cdedd0647b0c4204232
         env:
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
-        run: ./gradlew modrinth
+        with:
+          arguments: modrinth
+          gradle-home-cache-cleanup: true
+      - name: Archive Artifacts
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        if: success()
+        with:
+          name: Floodgate Fabric
+          path: build/libs/floodgate-fabric.jar
+          if-no-files-found: error

--- a/build.gradle
+++ b/build.gradle
@@ -52,13 +52,6 @@ dependencies {
         because "Commands library implementation for Fabric"
     })
 
-    include(modImplementation('net.kyori:adventure-platform-fabric:5.10.0') {
-        because "Chat library implementation for Fabric that includes methods for communicating with the server"
-        // Thanks to zml for this fix
-        // The package modifies Brigadier which causes a LinkageError at runtime if included
-        exclude group: 'ca.stellardrift', module: "colonel"
-    })
-
     // Lombok
     compileOnly "org.projectlombok:lombok:${project.lombok_version}"
     annotationProcessor "org.projectlombok:lombok:${project.lombok_version}"
@@ -68,12 +61,6 @@ repositories {
     //mavenLocal()
     maven {
         url = 'https://oss.sonatype.org/content/repositories/snapshots'
-    }
-    // specifically for adventure-platform-fabric:5.4.0-SNAPSHOT
-    maven {
-        name = "sonatype-oss-snapshots1"
-        url = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-        mavenContent { snapshotsOnly() }
     }
     // Standard OpenCollab repositories
     maven {
@@ -168,7 +155,7 @@ modrinth {
     syncBodyFrom = rootProject.file("README.md").text
 
     uploadFile = tasks.getByPath("remappedModrinthJar")
-    gameVersions.addAll("1.20.2")
+    gameVersions.addAll("1.20.4")
 
     loaders = ["fabric"]
 

--- a/build.gradle
+++ b/build.gradle
@@ -147,6 +147,7 @@ publishing {
 tasks.modrinth.dependsOn tasks.remappedModrinthJar
 
 modrinth {
+    token = System.getenv('MODRINTH_TOKEN') // Prevent GitHub Actions from caching empty Modrinth token
     projectId = "bWrNNfkb"
     versionNumber = project.version as String + "-" + System.getenv("GITHUB_RUN_NUMBER")
     versionType = "beta"
@@ -155,7 +156,7 @@ modrinth {
     syncBodyFrom = rootProject.file("README.md").text
 
     uploadFile = tasks.getByPath("remappedModrinthJar")
-    gameVersions.addAll("1.20.4")
+    gameVersions.addAll("1.20.2", "1.20.4")
 
     loaders = ["fabric"]
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,14 @@
 org.gradle.jvmargs=-Xmx2G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.20.2
-loader_version=0.14.22
+minecraft_version=1.20.4
+loader_version=0.15.2
 # Mod Properties
 mod_version=2.2.0-SNAPSHOT
 maven_group=org.geysermc.floodgate
 archives_base_name=floodgate-fabric
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.89.2+1.20.2
+fabric_version=0.91.2+1.20.4
 # Our stuff
 lombok_version=1.18.20

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,8 +24,8 @@
     "floodgate.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.15.2",
+    "fabricloader": ">=0.14.22",
     "fabric": "*",
-    "minecraft": ">=1.20.4"
+    "minecraft": ">=1.20.2"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,8 +24,8 @@
     "floodgate.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.14.22",
+    "fabricloader": ">=0.15.2",
     "fabric": "*",
-    "minecraft": ">=1.20.2"
+    "minecraft": ">=1.20.4"
   }
 }


### PR DESCRIPTION
Note that removing adventure-platform-fabric is required to support 1.20.4, but not the fabric bump itself.

We should drop 1.20.2 though, because Geyser-Fabric doesn't work on 1.20.2 due to ViaFabric not supporting 1.20.2