### PR TITLE
Ensure locales are found within Floodgate only

### DIFF
--- a/fabric/src/main/java/org/geysermc/floodgate/platform/fabric/FabricFloodgateMod.java
+++ b/fabric/src/main/java/org/geysermc/floodgate/platform/fabric/FabricFloodgateMod.java
@@ -7,6 +7,7 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.floodgate.core.module.PluginMessageModule;
 import org.geysermc.floodgate.core.module.ServerCommonModule;
 import org.geysermc.floodgate.mod.FloodgateMod;
@@ -17,6 +18,7 @@ import org.geysermc.floodgate.platform.fabric.util.TaskTimer;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -45,6 +47,12 @@ public final class FabricFloodgateMod extends FloodgateMod implements ModInitial
             ServerLifecycleEvents.SERVER_STOPPING.register($ -> this.disable());
         }
         TaskTimer.register();
+    }
+
+    @Override
+    public @Nullable URL resourceUrl(String file) throws IOException {
+        Path path = container.findPath(file).orElse(null);
+        return path == null ? null : path.toUri().toURL();
     }
 
     @Override

--- a/mod/src/main/java/org/geysermc/floodgate/mod/FloodgateMod.java
+++ b/mod/src/main/java/org/geysermc/floodgate/mod/FloodgateMod.java
@@ -5,6 +5,7 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import net.minecraft.server.MinecraftServer;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.floodgate.api.logger.FloodgateLogger;
 import org.geysermc.floodgate.core.FloodgatePlatform;
 import org.geysermc.floodgate.mod.module.ModAddonModule;
@@ -12,6 +13,7 @@ import org.geysermc.floodgate.mod.module.ModListenerModule;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 
 public abstract class FloodgateMod {
     public static FloodgateMod INSTANCE;
@@ -53,6 +55,8 @@ public abstract class FloodgateMod {
     protected void enable(Module... module) {
         platform.enable(module);
     }
+
+    public abstract @Nullable URL resourceUrl(String file) throws IOException;
 
     public abstract @NonNull InputStream resourceStream(String file) throws IOException;
 

--- a/mod/src/main/java/org/geysermc/floodgate/mod/mixin/LanguageManagerMixin.java
+++ b/mod/src/main/java/org/geysermc/floodgate/mod/mixin/LanguageManagerMixin.java
@@ -1,0 +1,23 @@
+package org.geysermc.floodgate.mod.mixin;
+
+import org.geysermc.floodgate.core.util.LanguageManager;
+import org.geysermc.floodgate.mod.FloodgateMod;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.io.IOException;
+import java.net.URL;
+
+@Mixin(value = LanguageManager.class, remap = false)
+public class LanguageManagerMixin {
+    @Redirect(method = "isValidLanguage",
+        at = @At(value = "INVOKE", target = "Ljava/lang/Class;getResource(Ljava/lang/String;)Ljava/net/URL;"))
+    private static URL floodgate$redirectUrl(Class<?> instance, String string) {
+        try {
+            return FloodgateMod.INSTANCE.resourceUrl(string);
+        } catch (IOException e) {
+            return null; // Likely doesn't exist, if it's something else, fallback should still work
+        }
+    }
+}

--- a/mod/src/main/resources/floodgate.mixins.json
+++ b/mod/src/main/resources/floodgate.mixins.json
@@ -1,20 +1,21 @@
 {
-  "required": true,
-  "minVersion": "0.8",
-  "package": "org.geysermc.floodgate.mod.mixin",
-  "compatibilityLevel": "JAVA_17",
-  "mixins": [
-    "ChunkMapMixin",
-    "ClientIntentionPacketMixin",
-    "ClientIntentionPacketMixinInterface",
-    "ConnectionMixin",
-    "FloodgateUtilMixin",
-    "GeyserModInjectorMixin",
-    "ServerConnectionListenerMixin",
-     "PlayerAccessor"
-  ],
-  "plugin": "org.geysermc.floodgate.mod.util.ModMixinConfigPlugin",
-  "injectors": {
-    "defaultRequire": 1
+    "required": true,
+    "minVersion": "0.8",
+    "package": "org.geysermc.floodgate.mod.mixin",
+    "compatibilityLevel": "JAVA_17",
+    "mixins": [
+        "ChunkMapMixin",
+        "ClientIntentionPacketMixin",
+        "ClientIntentionPacketMixinInterface",
+        "ConnectionMixin",
+        "FloodgateUtilMixin",
+        "GeyserModInjectorMixin",
+        "LanguageManagerMixin",
+        "PlayerAccessor",
+        "ServerConnectionListenerMixin"
+    ],
+    "plugin": "org.geysermc.floodgate.mod.util.ModMixinConfigPlugin",
+    "injectors": {
+        "defaultRequire": 1
   }
 }

--- a/neoforge/src/main/java/org/geysermc/floodgate/platform/neoforge/NeoForgeFloodgateMod.java
+++ b/neoforge/src/main/java/org/geysermc/floodgate/platform/neoforge/NeoForgeFloodgateMod.java
@@ -12,6 +12,7 @@ import net.neoforged.neoforge.event.server.ServerStoppingEvent;
 import net.neoforged.neoforge.event.tick.ServerTickEvent;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.floodgate.core.module.PluginMessageModule;
 import org.geysermc.floodgate.core.module.ServerCommonModule;
 import org.geysermc.floodgate.mod.FloodgateMod;
@@ -23,6 +24,8 @@ import org.geysermc.floodgate.platform.neoforge.util.TaskTimer;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
 import java.util.Objects;
 
 @Mod("floodgate")
@@ -70,6 +73,12 @@ public final class NeoForgeFloodgateMod extends FloodgateMod {
 
         // We can now trigger the registering of our plugin message channels
         enable(new PluginMessageModule());
+    }
+
+    @Override
+    public @Nullable URL resourceUrl(String file) throws IOException {
+        URI uri = container.getModInfo().getOwningFile().getFile().getContents().findFile(file).orElse(null);
+        return uri == null ? null : uri.toURL();
     }
 
     @Override


### PR DESCRIPTION
This fixes an issue where if a locale was present in Geyser but *not* floodgate, floodgate would assume the locale is present anyway and crash when trying to load it. This PR fixes it by ensuring files are only checked within floodgate's jar and not Geyser's.