### PR TITLE
Fix Modrinth game version for Floodgate-Modded

### DIFF
--- a/build-logic/src/main/kotlin/floodgate-modded.platform-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/floodgate-modded.platform-conventions.gradle.kts
@@ -139,6 +139,6 @@ modrinth {
     syncBodyFrom.set(rootProject.file("README.md").readText())
 
     uploadFile.set(project.layout.buildDirectory.file("libs/${versionName(project)}.jar"))
-    gameVersions.addAll(libs.minecraft.get().version as String, "26.1.1", "26.1.2")
+    gameVersions.addAll(libs.minecraft.get().version as String)
     failSilently.set(false)
 }


### PR DESCRIPTION
This PR removes 26.1.1 and 26.1.2 from the game versions on the Floodgate-Modded Modrinth page.

Resolves #163.